### PR TITLE
Update release notes generator with cleaner formatting, grouping, and trivial PR filtering

### DIFF
--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -39,9 +39,8 @@ def is_trivial_pr(title):
     """
     trivial_phrases = [
         "merge release", "merge master", "merge develop",
-        "sync master", "sync develop",
-        "update configs", "update .env",
-        "bump actions/checkout", "bump version", "update version"
+        "sync master", "sync develop", "update .env",
+        "bump actions/checkout", "bump version", "dependabot"
     ]
     t = title.lower()
     return any(p in t for p in trivial_phrases)
@@ -400,8 +399,17 @@ def release_notes(parsed_args):
                                             epic_set.add((epic_key,epic_title, epic_description, epic_status))
                                             pr_mapping.setdefault(epic_key, []).append(f"[{repo.name} PR #{pr.number}]({repo.html_url}/pull/{pr.number})")
                                         else:
-                                            issue_titles_other.append(
-                                                f"{jira_issue['fields']['summary'].strip()} (Jira {jira_issue['fields']['issuetype']['name']} : {jira_issue['key']})\n  - Description: {jira_issue['fields'].get('description', 'No description provided')} - Epic missing"
+                                            desc = jira_issue['fields'].get('description', 'No description provided')
+                                            if isinstance(desc, dict) and 'content' in desc:
+                                                cleaned = []
+                                                for block in desc.get('content', []):
+                                                    if block['type'] == 'paragraph':
+                                                        paragraph_text = " ".join(
+                                                            [item.get('text', '') for item in block.get('content', []) if item.get('type') == 'text']
+                                                        )
+                                                        cleaned.append(paragraph_text)
+                                                desc = "\n".join(cleaned) if cleaned else 'No description available'
+                                            issue_titles_other.append(f"{jira_issue['fields']['summary'].strip()} (Jira {jira_issue['fields']['issuetype']['name']} : {jira_issue['key']})\n  - Description: {desc} - Epic missing"
                                             )
 
                             elif pr_github_issues:

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -33,28 +33,27 @@ def get_repo_group(repo_name):
     else:
         return "Other Existing Repositories"
 
+import csv
+import os
+
 def format_repo_name(repo_name):
     """
-    Convert raw repo names to formatted display names for release notes compared with previous release.
+    Convert raw repo names to formatted display names for release notes.
+    Uses 'repo_name_map.csv' if available, otherwise falls back to default formatting.
     """
-    name_map = {
-        "carma-platform": "CARMA Platform", "carma-cloud": "CARMA Cloud", "carma-streets": "CARMA Streets",
-        "carma-messenger": "CARMA Messenger", "carma-messenger-bridge": "CARMA Messenger Bridge",
-        "carma-config": "CARMA Config", "carma-base": "CARMA Base", "carma-utils": "CARMA Utils",
-        "carma-msgs": "CARMA Msgs", "carma-lightbar-driver": "CARMA Lightbar Driver",
-        "carma-velodyne-lidar-driver": "CARMA Velodyne Lidar Driver",
-        "carma-novatel-oem-driver-wrapper": "CARMA Novatel OEM7 Driver Wrapper",
-        "carma-ssc-interface-wrapper": "CARMA SSC Interface Wrapper",
-        "carma-torc-pinpoint-driver": "CARMA Torc Pinpoint Driver", "carma-vehicle-calibration": "CARMA Vehicle Calibration",
-        "carma-analytics-fotda": "CARMA Analytics FOTDA", "carma-ns3-adapter": "CARMA NS3 Adapter",
-        "cdasim": "CDASim", "cda-telematics": "CDA Telematics",
-        "v2x-ros-driver": "V2X ROS Driver", "v2x-ros-conversion": "V2X ROS Conversion",
-        "stol-j2735": "STOL J2735", "autoware.auto": "Autoware.Auto", "autoware.ai": "Autoware.ai",
-        "ros1_bridge": "Ros1_bridge", "navigation2_extensions": "Navigation2 Extensions",
-        "navigation2": "Navigation2", "twist_to_ackermann": "Twist To Ackermann", "vesc": "VESC",
-        "c1t_bringup": "C1T Bringup", "c1t2x-emulator": "C1T2X Emulator",
-        "v2x-hub": "V2X Hub", "carma-web-ui": "CARMA Web UI"
-    }
+    name_map = {}
+    csv_file = os.path.join(os.path.dirname(__file__), "repo_name_map.csv")
+
+    if os.path.exists(csv_file):
+        try:
+            with open(csv_file, newline='', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if row.get("repo_name") and row.get("display_name"):
+                        name_map[row["repo_name"].strip().lower()] = row["display_name"].strip()
+        except Exception as e:
+            logging.warning(f"Could not read repo_name_map.csv ({e})")
+
     lower = repo_name.lower()
     return name_map.get(lower, " ".join(word.capitalize() for word in lower.replace("_", "-").split("-")))
 
@@ -428,9 +427,11 @@ def release_notes(parsed_args):
                                             if isinstance(desc, dict) and 'content' in desc:
                                                 cleaned = []
                                                 for block in desc.get('content', []):
+                                                    if not block or 'content' not in block:
+                                                        continue
                                                     if block['type'] == 'paragraph':
                                                         paragraph_text = " ".join(
-                                                            [item.get('text', '') for item in block.get('content', []) if item.get('type') == 'text']
+                                                            [item.get('text', '') for item in block.get('content', []) if item and item.get('type') == 'text']
                                                         )
                                                         cleaned.append(paragraph_text)
                                                 desc = "\n".join(cleaned) if cleaned else 'No description available'

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -17,6 +17,22 @@ from github import Github, GithubException
 skipped_repos = []
 skipped_prs = []
 
+# Grouping definitions for release notes
+KEY_EXISTING_REPOS = {"carma-platform", "carma-messenger", "carma-cloud"}
+PRIVATE_REPOS = {"carma-vehicle-calibration", "stol72735"}
+
+def get_repo_group(repo_name):
+    """
+    Determine which section the repository belongs to.
+    """
+    lower = repo_name.lower()
+    if lower in KEY_EXISTING_REPOS:
+        return "Changes to Key Existing Repositories"
+    elif lower in PRIVATE_REPOS:
+        return "Private Repositories"
+    else:
+        return "Other Existing Repositories"
+
 def get_jira_issue(issue_key, jira_url, jira_email, jira_token):
     """
     Function to get Jira issue details based on the Jira key.
@@ -197,7 +213,7 @@ def get_release_notes(name, version, epic_set,
     Returns:
         str: Formatted release notes in markdown.
     """
-    notes_content = f"\n\n## {name} - {version}\n"
+    notes_content = f"\n\n## {name}\n"
 
     # List of Jira Epics
     notes_content += "\n**List of Jira Epics**\n"
@@ -297,8 +313,13 @@ def release_notes(parsed_args):
         logging.error("%s", error)
         sys.exit(1)
 
+    sections = {
+        "Changes to Key Existing Repositories": [],
+        "Other Existing Repositories": [],
+        "Private Repositories": [],
+    }
+
     try:
-        notes = "# Releases"
         for org in parsed_args.organizations:
             for github_repo in get_repo_list(org, github):
                 logging.info("Processing %s", github_repo)
@@ -372,10 +393,13 @@ def release_notes(parsed_args):
                             logging.error("Error processing PR #%d for repo %s: %s", pr.number, repo.name, error)
                             skipped_prs.append(f"PR #{pr.number} in repo {repo.name} failed to process")
 
-                notes += get_release_notes(
+                repo_group = get_repo_group(repo.name)
+                repo_notes = get_release_notes(
                     repo.name, parsed_args.version, epic_set,
                     issue_titles_other, github_issues, pull_requests_missing_epics, commit_only, pr_mapping
                 )
+                sections[repo_group].append(repo_notes)
+
                 open_prs = []
                 for pr in repo.get_pulls(state="open"):
                     try:
@@ -384,8 +408,17 @@ def release_notes(parsed_args):
                     except GithubException:
                         continue
                 if open_prs:
-                    notes += "\n**Open PRs targeting release branch (excluded)**\n" + "\n".join(open_prs) + "\n"
+                    sections[repo_group].append("\n**Open PRs targeting release branch (excluded)**\n" + "\n".join(open_prs) + "\n")
                 logging.info("Generated release note for repo: %s", github_repo)
+
+        notes = "# CARMA System Release Notes\n"
+        notes += f"\nVersion {parsed_args.version}, released TBD\n"
+        notes += "\n---\n"
+        for section_title in ["Changes to Key Existing Repositories", "Other Existing Repositories", "Private Repositories"]:
+            if not sections[section_title]:
+                continue
+            notes += f"\n## {section_title}\n"
+            notes += "\n".join(sections[section_title])
 
         if skipped_repos:
             notes += "\n\n**Skipped Repositories**\n"

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -19,7 +19,7 @@ skipped_prs = []
 
 # Grouping definitions for release notes
 KEY_EXISTING_REPOS = {"carma-platform", "carma-messenger", "carma-cloud"}
-PRIVATE_REPOS = {"carma-vehicle-calibration", "stol72735"}
+PRIVATE_REPOS = {"carma-vehicle-calibration", "stol-j2735"}
 
 def get_repo_group(repo_name):
     """
@@ -32,6 +32,19 @@ def get_repo_group(repo_name):
         return "Private Repositories"
     else:
         return "Other Existing Repositories"
+
+def is_trivial_pr(title):
+    """
+    Return True if the PR title is with internal PRs(Like release process,GitHub Bot,etc) and should be skipped from release notes.
+    """
+    trivial_phrases = [
+        "merge release", "merge master", "merge develop",
+        "sync master", "sync develop",
+        "update configs", "update .env",
+        "bump actions/checkout", "bump version", "update version"
+    ]
+    t = title.lower()
+    return any(p in t for p in trivial_phrases)
 
 def get_jira_issue(issue_key, jira_url, jira_email, jira_token):
     """
@@ -226,7 +239,7 @@ def get_release_notes(name, version, epic_set,
             pr_numbers = pr_mapping.get(epic_key, [])
             pr_list = ', '.join(pr_numbers) if pr_numbers else "N/A"
             notes_content += f"* {epic_key}: {epic_title} (Status: {epic_status}): "
-            notes_content += f"{epic_description}. (GitHub PRs {pr_list})\n"
+            notes_content += f"{epic_description}.\n  - Pull Requests: {pr_list}\n"
 
     else:
         notes_content += "No Jira epics found\n"
@@ -369,6 +382,13 @@ def release_notes(parsed_args):
                             # Only process PRs that are closed and merged
                             if pr.state != "closed" or not pr.merged:
                                 continue
+                            if pr.draft:
+                                logging.info(f"Skipping draft PR: {pr.title}")
+                                continue
+                            # Skip trivial PRs that add no release-note value
+                            if is_trivial_pr(pr.title):
+                                logging.info(f"Skipping trivial PR:{pr.title}")
+                                continue    
                             jira_keys, pr_github_issues = get_issues_from_pr(repo, pr.number)
                             if jira_keys:
                                 for jira_key in jira_keys:
@@ -381,7 +401,7 @@ def release_notes(parsed_args):
                                             pr_mapping.setdefault(epic_key, []).append(f"[{repo.name} PR #{pr.number}]({repo.html_url}/pull/{pr.number})")
                                         else:
                                             issue_titles_other.append(
-                                                f"{jira_issue['fields']['summary'].strip()} (Jira {jira_issue['fields']['issuetype']['name']} : {jira_issue['key']}) - Epic missing"
+                                                f"{jira_issue['fields']['summary'].strip()} (Jira {jira_issue['fields']['issuetype']['name']} : {jira_issue['key']})\n  - Description: {jira_issue['fields'].get('description', 'No description provided')} - Epic missing"
                                             )
 
                             elif pr_github_issues:

--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -33,6 +33,31 @@ def get_repo_group(repo_name):
     else:
         return "Other Existing Repositories"
 
+def format_repo_name(repo_name):
+    """
+    Convert raw repo names to formatted display names for release notes compared with previous release.
+    """
+    name_map = {
+        "carma-platform": "CARMA Platform", "carma-cloud": "CARMA Cloud", "carma-streets": "CARMA Streets",
+        "carma-messenger": "CARMA Messenger", "carma-messenger-bridge": "CARMA Messenger Bridge",
+        "carma-config": "CARMA Config", "carma-base": "CARMA Base", "carma-utils": "CARMA Utils",
+        "carma-msgs": "CARMA Msgs", "carma-lightbar-driver": "CARMA Lightbar Driver",
+        "carma-velodyne-lidar-driver": "CARMA Velodyne Lidar Driver",
+        "carma-novatel-oem-driver-wrapper": "CARMA Novatel OEM7 Driver Wrapper",
+        "carma-ssc-interface-wrapper": "CARMA SSC Interface Wrapper",
+        "carma-torc-pinpoint-driver": "CARMA Torc Pinpoint Driver", "carma-vehicle-calibration": "CARMA Vehicle Calibration",
+        "carma-analytics-fotda": "CARMA Analytics FOTDA", "carma-ns3-adapter": "CARMA NS3 Adapter",
+        "cdasim": "CDASim", "cda-telematics": "CDA Telematics",
+        "v2x-ros-driver": "V2X ROS Driver", "v2x-ros-conversion": "V2X ROS Conversion",
+        "stol-j2735": "STOL J2735", "autoware.auto": "Autoware.Auto", "autoware.ai": "Autoware.ai",
+        "ros1_bridge": "Ros1_bridge", "navigation2_extensions": "Navigation2 Extensions",
+        "navigation2": "Navigation2", "twist_to_ackermann": "Twist To Ackermann", "vesc": "VESC",
+        "c1t_bringup": "C1T Bringup", "c1t2x-emulator": "C1T2X Emulator",
+        "v2x-hub": "V2X Hub", "carma-web-ui": "CARMA Web UI"
+    }
+    lower = repo_name.lower()
+    return name_map.get(lower, " ".join(word.capitalize() for word in lower.replace("_", "-").split("-")))
+
 def is_trivial_pr(title):
     """
     Return True if the PR title is with internal PRs(Like release process,GitHub Bot,etc) and should be skipped from release notes.
@@ -225,7 +250,7 @@ def get_release_notes(name, version, epic_set,
     Returns:
         str: Formatted release notes in markdown.
     """
-    notes_content = f"\n\n## {name}\n"
+    notes_content = f"\n\n## {format_repo_name(name)}\n"
 
     # List of Jira Epics
     notes_content += "\n**List of Jira Epics**\n"
@@ -233,8 +258,8 @@ def get_release_notes(name, version, epic_set,
         for epic_fields in sorted(epic_set):
             epic_key = epic_fields[0]
             epic_title = epic_fields[1]
-            epic_description = epic_fields[2] if len(epic_fields) >2 and epic_fields[2] else "No description provided"
-            epic_status = epic_fields[3] if len(epic_fields) > 3 and epic_fields[3] else "No status provided" 
+            epic_description = epic_fields[2] if len(epic_fields) > 2 and epic_fields[2] else "No description provided"
+            epic_status = epic_fields[3] if len(epic_fields) > 3 and epic_fields[3] else "No status provided"
             pr_numbers = pr_mapping.get(epic_key, [])
             pr_list = ', '.join(pr_numbers) if pr_numbers else "N/A"
             notes_content += f"* {epic_key}: {epic_title} (Status: {epic_status}): "
@@ -442,6 +467,8 @@ def release_notes(parsed_args):
         notes = "# CARMA System Release Notes\n"
         notes += f"\nVersion {parsed_args.version}, released TBD\n"
         notes += "\n---\n"
+        notes += "\n### Summary\n"
+
         for section_title in ["Changes to Key Existing Repositories", "Other Existing Repositories", "Private Repositories"]:
             if not sections[section_title]:
                 continue

--- a/repo_name_map.csv
+++ b/repo_name_map.csv
@@ -1,0 +1,34 @@
+repo_name,display_name
+carma-platform,CARMA Platform
+carma-cloud,CARMA Cloud
+carma-streets,CARMA Streets
+carma-messenger,CARMA Messenger
+carma-messenger-bridge,CARMA Messenger Bridge
+carma-config,CARMA Config
+carma-base,CARMA Base
+carma-utils,CARMA Utils
+carma-msgs,CARMA Msgs
+carma-lightbar-driver,CARMA Lightbar Driver
+carma-velodyne-lidar-driver,CARMA Velodyne Lidar Driver
+carma-novatel-oem-driver-wrapper,CARMA Novatel OEM7 Driver Wrapper
+carma-ssc-interface-wrapper,CARMA SSC Interface Wrapper
+carma-torc-pinpoint-driver,CARMA Torc Pinpoint Driver
+carma-vehicle-calibration,CARMA Vehicle Calibration
+carma-analytics-fotda,CARMA Analytics FOTDA
+carma-ns3-adapter,CARMA NS3 Adapter
+cdasim,CDASim
+cda-telematics,CDA Telematics
+v2x-ros-driver,V2X ROS Driver
+v2x-ros-conversion,V2X ROS Conversion
+stol-j2735,STOL J2735
+autoware.auto,Autoware.Auto
+autoware.ai,Autoware.ai
+ros1_bridge,Ros1_bridge
+navigation2_extensions,Navigation2 Extensions
+navigation2,Navigation2
+twist_to_ackermann,Twist To Ackermann
+vesc,VESC
+c1t_bringup,C1T Bringup
+c1t2x-emulator,C1T2X Emulator
+v2x-hub,V2X Hub
+carma-web-ui,CARMA Web UI


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
TThis PR improves the generate_release_notes.py script to make the release notes markdown output cleaner with formatting of previous releases notes.


Key Changes Included:

1. Added repository grouping logic using get_repo_group() to organize repositories under:
Changes to Key Existing Repositories (CARMA Platform, CARMA Messenger, CARMA Cloud)
Other Existing Repositories
Private Repositories (CARMA Vehicle Calibration, STOL J2735)
2. Removed the “New Repositories” section from the markdown template (can be added manually if needed).
3. Added format_repo_name() function to display repository names in proper case and remove version suffixes (e.g., autoware.auto - carma-system-4.11.0 → Autoware.Auto).
4 Updated release notes header template to match the official CARMA style and structure.
5. Reformatted GitHub PR listings under Jira Epics — PRs are now listed as below instead of being appended inline at the end of the description.
- Pull Requests: carma-platform PR #2563, carma-platform PR #2575
6. Added Jira Story descriptions in the “Other Jira Items” section using Jira API response.
7. Implemented filters to skip trivial PRs such as:
Merge release/master/develop branches
Sync master/develop
Update .env or configs
Bump version or actions
Hotfix version bumps
8. Added logic to skip draft PRs from inclusion in release notes.
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[OMDO-66](https://usdot-carma.atlassian.net/browse/OMDO-66)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in local using below command and also triggered on GitHub actions (https://github.com/usdot-fhwa-stol/devops/actions)

python3 generate_release_notes.py --github-token "$TOKEN" --release-branch "release/tempest" --stable-branch "master" --organizations "usdot-fhwa-stol" --output-file "release_notes.md" --version "Test1.0.5" --jira-url "https://usdot-carma.atlassian.net/" --jira-email "EMAIL" --jira-token "JIRA TOKEN"
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[Release_Notes_Test-1.0.7.md.zip](https://github.com/user-attachments/files/23364348/Release_Notes_Test-1.0.7.md.zip)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[OMDO-66]: https://usdot-carma.atlassian.net/browse/OMDO-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ